### PR TITLE
Fix and unittest lqueue functions in trick_adt.

### DIFF
--- a/include/trick/lqueue.h
+++ b/include/trick/lqueue.h
@@ -21,6 +21,7 @@ typedef struct _LQUEUE
 
 LQUEUE* LQ_Create(void);   /* create and initialize a LQUEUE */
 
+int LQ_Delete(LQUEUE* lqueue); /* free an lqueue object created by LQ_Create.*/
 
 void LQ_Init(LQUEUE*);     /* initialize a LQUEUE */
 

--- a/trick_source/trick_utils/trick_adt/src/lqueue.c
+++ b/trick_source/trick_utils/trick_adt/src/lqueue.c
@@ -16,11 +16,24 @@ LQUEUE *LQ_Create(void)
     return ret;
 }
 
+int LQ_Delete(LQUEUE* lqueue) {
+
+    if (lqueue == NULL) {
+        fprintf(stderr, "Error (%s): Pointer to LQUEUE is NULL.\n", __FUNCTION__ );
+        fflush(stderr);
+        return -1;
+    }
+    DLL_Delete(&lqueue->list);
+    return 0;
+}
 
 /* initialize a queue created statically */
 void LQ_Init(LQUEUE * pQueue)
 {
-
+    if (pQueue == NULL) {
+        fprintf(stderr, "Error (%s): Pointer to LQUEUE is NULL.\n", __FUNCTION__ );
+        fflush(stderr);
+    }
     DLL_Init(&(pQueue->list));
 }
 
@@ -31,7 +44,7 @@ void LQ_EnQ(void *pData, LQUEUE * pQueue)
 {
 
     if (pQueue == NULL) {
-        fprintf(stderr, "Queue is NULL");
+        fprintf(stderr, "Error (%s): Pointer to LQUEUE is NULL.", __FUNCTION__ );
         return;
     }
 
@@ -43,8 +56,14 @@ void LQ_EnQ(void *pData, LQUEUE * pQueue)
 
 void *LQ_DeQ(LQUEUE * pQueue)
 {
-    if (LQ_GetCount(pQueue) > 0)
+    if (pQueue == NULL) {
+        fprintf(stderr, "Error (%s): Pointer to LQUEUE is NULL.", __FUNCTION__ );
+        return NULL;
+    }
+
+    if (LQ_GetCount(pQueue) > 0) {
         return DLL_RemoveAt(DLL_GetTailPosition(&(pQueue->list)), &(pQueue->list));
+    }
     return NULL;
 }
 
@@ -53,15 +72,19 @@ void *LQ_DeQ(LQUEUE * pQueue)
 
 void *LQ_Peek(LQUEUE * pQueue)
 {
-
-    if (pQueue == NULL && DLL_GetCount(&(pQueue->list)) <= 0) {
-        fprintf(stderr, "Queue is NULL and number of elements is 0");
+    if (pQueue == NULL) {
+        fprintf(stderr, "Error (%s): Pointer to LQUEUE is NULL.", __FUNCTION__);
+        fflush(stderr);
         return NULL;
     }
 
-    if (pQueue != NULL)
-        return DLL_GetAt(DLL_GetTailPosition(&(pQueue->list)), &(pQueue->list));
-    return NULL;
+    if ( DLL_GetCount( &(pQueue->list)) <= 0) {
+        fprintf(stderr, "Error (%s): LQUEUE is empty.", __FUNCTION__);
+        fflush(stderr);
+        return NULL;
+    }
+
+    return DLL_GetAt(DLL_GetTailPosition(&(pQueue->list)), &(pQueue->list));
 }
 
 
@@ -71,7 +94,7 @@ int LQ_GetCount(LQUEUE * pQueue)
 {
 
     if (pQueue == NULL) {
-        fprintf(stderr, "Queue is NULL");
+        fprintf(stderr, "Error (%s): Pointer to LQUEUE is NULL.", __FUNCTION__ );
         return -1;
     }
 

--- a/trick_source/trick_utils/trick_adt/test/Makefile
+++ b/trick_source/trick_utils/trick_adt/test/Makefile
@@ -18,7 +18,8 @@ TRICK_EXEC_LINK_LIBS += -lpthread
 # ==================================================================================
 # All tests produced by this Makefile. Add new tests you create to this list.
 # ==================================================================================
-TESTS = dllist_unittest
+TESTS = dllist_unittest\
+        lqueue_unittest
 
 # List of XML files produced by the tests.
 unittest_results = $(patsubst %,%.xml,$(TESTS))
@@ -58,3 +59,7 @@ $(unittest_objects): %.o: %.cpp
 # ==================================================================================
 $(TESTS) : %: %.o
 	$(TRICK_CXX) $(TRICK_SYSTEM_LDFLAGS) -o $@ $^ -L${TRICK_HOME}/lib_${TRICK_HOST_CPU} $(TRICK_LIBS) $(TRICK_EXEC_LINK_LIBS)
+
+# ----------------------------------------------------------------------------------
+# The following unittest programs are also dependent on the indicated object files.
+# ----------------------------------------------------------------------------------

--- a/trick_source/trick_utils/trick_adt/test/lqueue_unittest.cpp
+++ b/trick_source/trick_utils/trick_adt/test/lqueue_unittest.cpp
@@ -1,0 +1,142 @@
+#include <gtest/gtest.h>
+#include <iostream>
+#include "trick/lqueue.h"
+
+/*
+
+LQUEUE* LQ_Create(void);
+int LQ_Delete(LQUEUE* lqueue);              free an lqueue object created by LQ_Create.
+void LQ_Init(LQUEUE*);
+void LQ_EnQ(void* pData,LQUEUE* pQueue);    insert data into queue
+void* LQ_DeQ(LQUEUE* pQueue);               extract data from queue
+void* LQ_Peek(LQUEUE* pQueue);              get data off queue without extracting
+int LQ_GetCount(LQUEUE* pQueue);            returns number of items in the queue
+
+BUG: There's no way to free an LQUEUE without a memory leak.
+*/
+
+
+
+TEST(lqueue_test, LQUEUE_Create) {
+    LQUEUE* result = LQ_Create();
+    EXPECT_NE(result, nullptr);
+    EXPECT_EQ( LQ_GetCount(result), 0);
+}
+
+TEST(lqueue_test, LQUEUE_Delete) {
+    LQUEUE* lqueue = LQ_Create();
+    EXPECT_EQ( LQ_Delete(lqueue), 0);
+}
+
+TEST(lqueue_test, LQUEUE_Delete_null) {
+
+    LQUEUE* lqueue = nullptr;
+    std::cout << "NOTE: An error message is expected to follow." << std::endl;
+    EXPECT_EQ( LQ_Delete(lqueue), -1);
+}
+
+TEST(lqueue_test, LQUEUE_Init) {
+
+    LQUEUE* lqueue = LQ_Create();
+    lqueue->list.count = 1;
+    lqueue->list.head = (DLLNODE*)(0xDEADBEEF);
+    lqueue->list.tail = (DLLNODE*)(0xDEADBEEF);
+    LQ_Init(lqueue);
+    EXPECT_EQ(lqueue->list.count, 0);
+    EXPECT_EQ(lqueue->list.head, nullptr);
+    EXPECT_EQ(lqueue->list.tail, nullptr);
+    EXPECT_EQ(lqueue->list.compare, nullptr);
+    EXPECT_EQ( LQ_GetCount(lqueue), 0);
+}
+
+TEST(lqueue_test, LQUEUE_Init_null) {
+
+    LQUEUE* lqueue = nullptr;
+    std::cout << "NOTE: Two error messages are expected to follow." << std::endl;
+    LQ_Init(lqueue);
+
+}
+
+TEST(lqueue_test, LQUEUE_EnQ) {
+    int A,B,C;
+    A=1; B=2; C=3;
+    LQUEUE* lqueue = LQ_Create();
+    LQ_EnQ( &A, lqueue);
+    EXPECT_EQ( LQ_GetCount(lqueue), 1);
+    LQ_EnQ( &B, lqueue);
+    EXPECT_EQ( LQ_GetCount(lqueue), 2);
+    LQ_EnQ( &C, lqueue);
+    EXPECT_EQ( LQ_GetCount(lqueue), 3);
+}
+
+TEST(lqueue_test, LQUEUE_EnQ_null_queue) {
+    int A,B,C;
+    A=1; B=2; C=3;
+    LQUEUE* lqueue = LQ_Create();
+    std::cout << "NOTE: An error message is expected to follow." << std::endl;
+    LQ_EnQ( &A, nullptr);
+
+}
+
+TEST(lqueue_test, LQUEUE_DeQ) {
+    int A,B,C;
+    A=1; B=2; C=3;
+    LQUEUE* lqueue = LQ_Create();
+    LQ_EnQ( &A, lqueue);
+    LQ_EnQ( &B, lqueue);
+    LQ_EnQ( &C, lqueue);
+    EXPECT_EQ( LQ_GetCount(lqueue), 3);
+    LQ_DeQ( lqueue);
+    EXPECT_EQ( LQ_GetCount(lqueue), 2);
+    LQ_DeQ( lqueue);
+    EXPECT_EQ( LQ_GetCount(lqueue), 1);
+    LQ_DeQ( lqueue);
+    EXPECT_EQ( LQ_GetCount(lqueue), 0);
+}
+
+TEST(lqueue_test, LQUEUE_DeQ_null_queue) {
+    int A,B,C;
+    A=1; B=2; C=3;
+    LQUEUE* lqueue = nullptr;
+    std::cout << "NOTE: An error message is expected to follow." << std::endl;
+    LQ_EnQ( &A, lqueue);
+}
+
+TEST(lqueue_test, LQUEUE_Peek) {
+    int A,B,C;
+    A=1; B=2; C=3;
+    int* result;
+    LQUEUE* lqueue = LQ_Create();
+    LQ_EnQ( &A, lqueue);
+    LQ_EnQ( &B, lqueue);
+    LQ_EnQ( &C, lqueue);
+
+    EXPECT_EQ( LQ_GetCount(lqueue), 3);
+    result = (int*)LQ_Peek(lqueue);
+    EXPECT_EQ(*result, 1);
+    LQ_DeQ( lqueue);
+
+    EXPECT_EQ( LQ_GetCount(lqueue), 2);
+    result = (int*)LQ_Peek(lqueue);
+    EXPECT_EQ(*result, 2);
+    LQ_DeQ( lqueue);
+
+    EXPECT_EQ( LQ_GetCount(lqueue), 1);
+    result = (int*)LQ_Peek(lqueue);
+    EXPECT_EQ(*result, 3);
+    LQ_DeQ( lqueue);
+
+    EXPECT_EQ( LQ_GetCount(lqueue), 0);
+    std::cout << "NOTE: An error message is expected to follow." << std::endl;
+    result = (int*)LQ_Peek(lqueue);
+    EXPECT_EQ(result, nullptr);
+}
+
+TEST(lqueue_test, LQUEUE_Peek_null_queue) {
+    int A,B,C;
+    A=1; B=2; C=3;
+    int* result = (int*)(0xDEADBEEF);;
+    LQUEUE* lqueue = nullptr;
+    result = (int*)LQ_Peek(lqueue);
+    EXPECT_EQ(result, nullptr);
+}


### PR DESCRIPTION
### Description

In this pull request, we have made modifications and additions to the LQUEUE (linked queue) data structure implementation along with unit tests for it.

**Changes:**
- Added a new function `int LQ_Delete(LQUEUE* lqueue)` to free an LQUEUE object created by `LQ_Create`.
- Implemented checking for NULL pointer in the `LQ_Init`, `LQ_EnQ`, `LQ_DeQ`, `LQ_Peek`, and `LQ_GetCount` functions to avoid potential errors.
- Added a new unit test file `lqueue_unittest.cpp` to test various functionalities of the LQUEUE data structure.
- Modified the Makefile to include the new unit test file `lqueue_unittest.cpp`.
- Added unit tests for `LQ_Create`, `LQ_Delete`, `LQ_Init`, `LQ_EnQ`, `LQ_DeQ`, and `LQ_Peek` functions of the LQUEUE data structure.
- Added test cases to validate error handling for NULL pointers and correct functioning of the LQUEUE functions.

These changes enhance the reliability and robustness of the LQUEUE data structure implementation by adding proper memory management and error handling.

Please review the code changes to ensure they meet the requirements and do not introduce any regressions.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

```markdown
### What change is being made?
Add `LQ_Delete` function to free `LQUEUE` objects and implement unit tests for `lqueue` functions in the `trick_adt` module.

### Why are these changes being made?
Previously, there was no way to free an `LQUEUE` object without causing a memory leak, which is addressed by the new `LQ_Delete` function. Additionally, comprehensive unit tests have been added to ensure the correctness and robustness of the `lqueue` functions, improving code reliability and maintainability.
```

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->