### PR TITLE
message

### DIFF
--- a/include/trick/message_proto.h
+++ b/include/trick/message_proto.h
@@ -9,6 +9,9 @@
 extern "C" {
 #endif
 
+int message_add_subscriber( void * in_ms ) ;
+int message_remove_subscriber( void * in_ms ) ;
+void * message_get_subscriber( const char * sub_name) ;
 int message_publish(int level, const char *format_msg, ...) ;
 int message_publish_standalone(int level, const char *format_msg, ...) ;
 int send_hs(FILE * fp, const char *format_msg, ...) ;

--- a/trick_source/sim_services/Message/Message_c_intf.cpp
+++ b/trick_source/sim_services/Message/Message_c_intf.cpp
@@ -24,7 +24,7 @@ int message_subscribe( Trick::MessageSubscriber * in_ms ) {
     the_message_publisher->subscribe(in_ms) ;
     return(0) ;
 }
-
+ 
 /**
  @relates Trick::MessagePublisher
  @copydoc Trick::MessagePublisher::unsubscribe
@@ -32,6 +32,33 @@ int message_subscribe( Trick::MessageSubscriber * in_ms ) {
 int message_unsubscribe( Trick::MessageSubscriber * in_ms ) {
     the_message_publisher->unsubscribe(in_ms) ;
     return(0) ;
+}
+
+
+/**
+ @relates Trick::MessagePublisher
+ @copydoc Trick::MessagePublisher::subscribe
+ */
+extern "C" int message_add_subscriber( void * in_ms ) {
+    the_message_publisher->subscribe((Trick::MessageSubscriber *)in_ms) ;
+    return(0) ;
+}
+ 
+/**
+ @relates Trick::MessagePublisher
+ @copydoc Trick::MessagePublisher::unsubscribe
+ */
+extern "C" int message_remove_subscriber( void * in_ms ) {
+    the_message_publisher->unsubscribe((Trick::MessageSubscriber *)in_ms) ;
+    return(0) ;
+}
+
+/**
+ @relates Trick::MessagePublisher
+ @copydoc Trick::MessagePublisher::getSubscriber
+ */
+extern "C" void * message_get_subscriber( const char * sub_name ) {
+    return (void *)the_message_publisher->getSubscriber(sub_name) ;
 }
 
 /**


### PR DESCRIPTION
### Description

The changes in this pull request are related to handling message subscribers in the Trick simulation environment. The modifications include adding functions to add, remove, and get subscribers for messages being published.

Here is a breakdown of the changes made in the code:

- Added new functions to manipulate message subscribers:
  - `message_add_subscriber`: Function to add a subscriber for messages.
  - `message_remove_subscriber`: Function to remove a subscriber for messages.
  - `message_get_subscriber`: Function to retrieve a subscriber based on the subscriber name.

- Modified the existing code to include these new functions for managing message subscribers.

These changes enhance the functionality of managing subscribers for published messages in the simulation environment.